### PR TITLE
Set network capabilities to cloudflared

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ script:
   - "ansible-playbook -i tests/inventory tests/$TESTBOOK --syntax-check"
   # Run role and ensure it completes successfully.
   - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags systemd"
+  # Check setting ansible port
+  - "ansible-playbook -i tests/inventory tests/$TESTBOOK --extra-vars 'cloudflared_port=53' --skip-tags systemd"
   # Run role again and check for idempotence.
   - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags systemd | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
   # Check cloudflared has been installed correctly

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_install:
   - sudo apt-get update -qq
 
 install:
+  #Workaround for ssl exception
+  - wget https://bin.equinox.io/c/VdrWdbjqyF/cloudflared-stable-linux-amd64.deb -P /tmp/
+
   # Install Ansible.
   - pip install ansible
 
@@ -19,8 +22,8 @@ script:
   # Check the role/playbook's syntax.
   - "ansible-playbook -i tests/inventory tests/$TESTBOOK --syntax-check"
   # Run role and ensure it completes successfully.
-  - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags web-api"
+  - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags systemd"
   # Run role again and check for idempotence.
-  - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags web-api | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
+  - "ansible-playbook -i tests/inventory tests/$TESTBOOK --skip-tags systemd | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' && exit 0) || (echo 'Idempotence test: fail' && exit 1)"
   # Check cloudflared has been installed correctly
   - "cloudflared"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,12 @@
   import_tasks: install_binary.yml
   when: (not cloudflared_installed) and (pkg_mgr_output is undefined or pkg_mgr_output is failed)
 
+- name: Set network capabilities for cloudflared
+  capabilities:
+    path: "{{ cloudflared_bin_location }}/cloudflared"
+    capability: cap_net_bind_service+ep
+    state: present
+
 - command: cloudflared update
   register: update_command
   changed_when: update_command.rc == '64'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
     owner: cloudflared
     group: cloudflared
   notify: restart cloudflared service
+  tags: systemd
 
 - name: copy systemd service
   copy:
@@ -46,12 +47,14 @@
     mode: 0644
   notify: restart cloudflared service
   register: service
+  tags: systemd
 
 - name: enable systemd service
   service:
     name: cloudflared
     enabled: "{{ cloudflared_enable_service }}"
   when: service.changed
+  tags: systemd
 
 - name: Allow port in firewall
   ufw:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
     path: "{{ cloudflared_bin_location }}/cloudflared"
     capability: cap_net_bind_service+ep
     state: present
+  when: cloudflared_port|int < 1024
 
 - command: cloudflared update
   register: update_command

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,10 +4,10 @@
   become: yes
   tasks:
 
-    - name: Test role with variables
-      include_role:
-        name: ../ansible-cloudflared
-      vars:
+  - name: Test role with variables
+    include_role:
+      name: ../ansible-cloudflared
+    vars:
       cloudflared_allow_firewall: false
       cloudflared_enable_service: false
       cloudflared_port: 5053


### PR DESCRIPTION
It enables using cloudflared on low ports without superuser permissions and only that action. That is useful when you install cloudflared locally to obfuscate all your outbound traffic even in local network.

What do you think about this change?