### PR TITLE
Small improvements

### DIFF
--- a/files/cloudflared.service
+++ b/files/cloudflared.service
@@ -4,7 +4,7 @@ After=syslog.target network-online.target
 
 [Service]
 Type=simple
-User=cloudflared
+User=nobody
 EnvironmentFile=/etc/default/cloudflared
 ExecStart=/usr/local/bin/cloudflared $CLOUDFLARED_OPTS
 Restart=on-failure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,11 +29,6 @@
   register: update_command
   changed_when: update_command.rc == '64'
 
-- name: create application user
-  user:
-    name: cloudflared
-    system: yes
-
 - name: template config file
   template:
     src: cloudflared.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 - name: copy systemd service
   copy:
     src: cloudflared.service
-    dest: /lib/systemd/system/
+    dest: /etc/systemd/system/
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
- The systemd .service file is installed under /lib while the recommended location is under /etc. This PR moves the file location.
- The role creates a `cloudflared` user while it can easily run as `nobody` since it requires no specific user privileges. This PR no longer creates the dedicated user and updates the user under which the service runs.