### PR TITLE
ignore errors on "cloudflared update"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
 - command: cloudflared update
   register: update_command
   changed_when: update_command.rc == '64'
+  ignore_errors: yes
 
 - name: template config file
   template:


### PR DESCRIPTION
Due to [this upstream cloudflared bug](https://github.com/cloudflare/cloudflared/issues/200) `cloudflared update` seems to be failing with error code 11 and breaking this role. This PR simply tells ansible to ignore errors on that command.