### PR TITLE
add extra daemon param, flush handler, revert to cloudflared user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,9 +11,14 @@ cloudflared_arm_binary: "cloudflared-stable-linux-arm.tgz"
 
 cloudflared_allow_firewall: false
 cloudflared_enable_service: true
-cloudflared_upstream: "https://1.1.1.1/dns-query"
-cloudflared_port: 5053
-
-cloudflared_options: "proxy-dns --port {{ cloudflared_port }} --upstream {{ cloudflared_upstream }}"
-
 cloudflared_bin_location: /usr/local/bin
+
+#Listen on given port for the DNS over HTTPS proxy server. (default: 53)
+cloudflared_port: 5053
+#Listen address for metrics reporting. (default: "localhost")
+cloudflared_metrics_address: 
+#Listen address for the DNS over HTTPS proxy server. (default: "localhost")
+cloudflared_dns_address: 
+#Upstream endpoint URL, you can specify multiple endpoints for redundancy.
+#(default: "https://1.1.1.1/dns-query", "https://1.0.0.1/dns-query")
+cloudflared_upstream: 

--- a/files/cloudflared.service
+++ b/files/cloudflared.service
@@ -4,7 +4,7 @@ After=syslog.target network-online.target
 
 [Service]
 Type=simple
-User=nobody
+User=cloudflared
 EnvironmentFile=/etc/default/cloudflared
 ExecStart=/usr/local/bin/cloudflared $CLOUDFLARED_OPTS
 Restart=on-failure

--- a/files/cloudflared.service
+++ b/files/cloudflared.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=cloudflared service
+Description=cloudflared DNS over HTTPS proxy
 After=syslog.target network-online.target
 
 [Service]
 Type=simple
 User=cloudflared
 EnvironmentFile=/etc/default/cloudflared
-ExecStart=/usr/local/bin/cloudflared $CLOUDFLARED_OPTS
+ExecStart=/usr/local/bin/cloudflared proxy-dns $CLOUDFLARED_OPTS
 Restart=on-failure
 RestartSec=10
 KillMode=process

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,13 +28,18 @@
 - command: cloudflared update
   register: update_command
   changed_when: update_command.rc == '64'
+  
+- name: create application user
+  user:
+    name: cloudflared
+    system: yes
 
 - name: template config file
   template:
     src: cloudflared.j2
     dest: /etc/default/cloudflared
-    owner: nobody
-    group: nogroup
+    owner: cloudflared
+    group: cloudflared
   notify: restart cloudflared service
   tags: systemd
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
 - command: cloudflared update
   register: update_command
   changed_when: update_command.rc == '64'
-  
+
 - name: create application user
   user:
     name: cloudflared
@@ -67,3 +67,5 @@
     port: "{{ cloudflared_port }}"
     comment: "allow cloudflared"
   when: cloudflared_allow_firewall
+
+- meta: flush_handlers

--- a/templates/cloudflared.j2
+++ b/templates/cloudflared.j2
@@ -1,2 +1,5 @@
 # Commandline args for cloudflared
-CLOUDFLARED_OPTS={{ cloudflared_options }}
+CLOUDFLARED_OPTS={% if cloudflared_port is not none %}--port {{ cloudflared_port }} {% endif %}
+{% if cloudflared_metrics_address is not none %}--metrics {{ cloudflared_metrics_address }} {% endif %}
+{% if cloudflared_dns_address is not none %}--address {{ cloudflared_dns_address }} {% endif %}
+{% if cloudflared_upstream is not none %}--upstream {{ cloudflared_upstream }} {% endif %}


### PR DESCRIPTION
revert to clouflared user, nobody never good.
security wise it's never a good idea to run a daemon as nobody.
add extra daemon param.
add a flush handler, to make sure the deamon is restarted if needed for next part of the play that can be impacted if dns is not correct anymore. 